### PR TITLE
Remove platform option and use HUD option instead

### DIFF
--- a/bkcore/hexgl/HexGL.js
+++ b/bkcore/hexgl/HexGL.js
@@ -23,12 +23,6 @@ bkcore.hexgl.HexGL = function(opts)
 	this.displayHUD = opts.hud == undefined ? true : opts.hud;
 	this.width = opts.width == undefined ? window.innerWidth : opts.width;
 	this.height = opts.height == undefined ? window.innerHeight : opts.height;
-
-	this.quality = opts.quality == undefined ? 2 : opts.quality;
-	
-	// TODO remove mobile variable
-	var mobile = true;
-	this.half = mobile && this.quality < 1;
 	
 	this.difficulty = opts.difficulty == undefined ? 0 : opts.difficulty;
 	this.player = opts.player == undefined ? "Anonym" : opts.player;
@@ -38,8 +32,17 @@ bkcore.hexgl.HexGL = function(opts)
 	this.mode = opts.mode == undefined ? 'timeattack' : opts.mode;
 
 	this.controlType = opts.controlType == undefined ? 1 : opts.controlType;
+	
+	// 0 == low, 1 == mid, 2 == high, 3 == very high
+	// the old platform+quality combinations map to these new quality values
+	// as follows:
+	// mobile + low quality => 0 (LOW)
+	// mobile + mid quality OR desktop + low quality => 1 (MID)
+	// mobile + high quality => 2 (HIGH)
+	// desktop + mid or high quality => 3 (VERY HIGH)
+	this.quality = opts.quality == undefined ? 3 : opts.quality;
 
-	if(this.half)
+	if(this.quality === 0)
 	{
 		this.width /= 2;
 		this.height /=2;
@@ -274,11 +277,8 @@ bkcore.hexgl.HexGL.prototype.initRenderer = function()
 		clearColor: 0x000000
 	});
 
-	// TODO remove mobile var
-	var mobile = true;
-	
 	// desktop + quality mid or high
-	if(this.quality > 0 && !mobile)
+	if(this.quality > 2)
 	{
 		renderer.physicallyBasedShading = true;
 		renderer.gammaInput = true;
@@ -352,11 +352,8 @@ bkcore.hexgl.HexGL.prototype.initGameComposer = function()
 	
 	// }
 	
-	// TODO remove mobile var
-	var mobile = true;
-	
 	// desktop + quality mid or high
-	if(this.quality > 1 && !mobile)
+	if(this.quality > 2)
 	{
 		var effectBloom = new THREE.BloomPass( 0.8, 25, 4 , 256);
 
@@ -365,16 +362,13 @@ bkcore.hexgl.HexGL.prototype.initGameComposer = function()
 		this.extras.bloom = effectBloom;
 	}
 
-	// TODO remove mobile var
 	// desktop + quality low, mid or high
 	// OR
 	// mobile + quality mid or high
-	if(!mobile || this.quality > 0)
+	if(this.quality > 0)
 		this.composers.game.addPass( effectHex );
 	else
 		this.composers.game.addPass( effectScreen );
-
-
 }
 
 bkcore.hexgl.HexGL.prototype.createMesh = function(parent, geometry, x, y, z, mat)
@@ -385,11 +379,8 @@ bkcore.hexgl.HexGL.prototype.createMesh = function(parent, geometry, x, y, z, ma
 	mesh.position.set( x, y, z );
 	parent.add(mesh);
 
-	// TODO remove mobile var
-	var mobile = true;
-	
 	// desktop + quality mid or high
-	if(this.quality > 0 && !mobile)
+	if(this.quality > 2)
 	{
 		mesh.castShadow = true;
 		mesh.receiveShadow = true;

--- a/bkcore/hexgl/tracks/Cityscape.js
+++ b/bkcore/hexgl/tracks/Cityscape.js
@@ -39,15 +39,12 @@ bkcore.hexgl.tracks.Cityscape = {
 
 	load: function(opts, quality)
 	{
-		// TODO remove mobile var
-		var mobile = true;
-		
 		this.lib = new bkcore.threejs.Loader(opts);
 
 		// desktop + quality low
 		// OR
 		// mobile + quality low or mid
-		if((quality < 1 && !mobile) || quality < 2) // LOW
+		if(quality < 2) // LOW
 		{
 			this.lib.load({
 				textures: {
@@ -150,13 +147,10 @@ bkcore.hexgl.tracks.Cityscape = {
 
 	buildMaterials: function(quality)
 	{
-		// TODO remove mobile var
-		var mobile = true;
-		
 		// desktop + quality low
 		// OR
 		// mobile + quality low or mid
-		if((quality < 1 && !mobile) || quality < 2) // LOW
+		if(quality < 2) // LOW
 		{
 			this.materials.track = new THREE.MeshBasicMaterial({
 				map: this.lib.get("textures", "track.cityscape.diffuse"),
@@ -290,9 +284,6 @@ bkcore.hexgl.tracks.Cityscape = {
 
 	buildScenes: function(ctx, quality)
 	{
-		// TODO remove mobile var
-		var mobile = true;
-		
 		// IMPORTANT
 		this.analyser = this.lib.get("analysers", "track.cityscape.collision");
 
@@ -335,7 +326,7 @@ bkcore.hexgl.tracks.Cityscape = {
 		sun.lookAt(new THREE.Vector3());
 
 		// desktop + quality mid or high
-		if(quality > 0 && !mobile)
+		if(quality > 2)
 		{
 			sun.castShadow = true;
 			sun.shadowCameraNear = 50;
@@ -371,7 +362,13 @@ bkcore.hexgl.tracks.Cityscape = {
 		var boosterLight = new THREE.PointLight(0x00a2ff, 4.0, 60);
 		boosterLight.position.set(0, 0.665, -4);
 		
-		// desktop or mobile + quality mid or high
+		// desktop + quality low, mid or high
+		// OR
+		// mobile + quality mid or high
+		// NB booster is now enabled on desktop + low quality,
+		// when it wasn't before; this is because this booster setting
+		// is the only difference between mobile + mid quality
+		// and desktop + low quality, so I merged them for convenience
 		if(quality > 0)
 			ship.add(boosterLight);
 
@@ -399,7 +396,7 @@ bkcore.hexgl.tracks.Cityscape = {
 		};
 		
 		// desktop + quality mid or high
-		if(quality > 0 && !mobile)
+		if(quality > 2)
 		{
 			fxParams.textureCloud = this.lib.get("textures", "cloud");
 			fxParams.textureSpark = this.lib.get("textures", "spark");

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
           <div id="start">Start</div>
           <div id="s-controlType">Controls: LeapMotion</div>
           <div id="s-quality">Quality: High</div>
-          <div id="s-platform">Platform: Desktop</div>
+          <div id="s-hud">HUD: On</div>
           <div id="s-godmode">Godmode: On</div>
         </div>
       </div>

--- a/launch.coffee
+++ b/launch.coffee
@@ -35,7 +35,7 @@ init = (controlType, quality, hud, godmode) ->
 u = bkcore.Utils.getURLParameter
 s = [
   ['controlType', ['KEYBOARD', 'TOUCH', 'LEAP MOTION CONTROLLER', 'GAMEPAD'], 0, 0, 'Controls: ']
-  ['quality', ['LOW', 'MID', 'HIGH'], 2, 2, 'Quality: ']
+  ['quality', ['LOW', 'MID', 'HIGH', 'VERY HIGH'], 3, 3, 'Quality: ']
   ['hud', ['OFF', 'ON'], 1, 1, 'HUD: ']
   ['godmode', ['OFF', 'ON'], 0, 1, 'Godmode: ']
 ]

--- a/launch.js
+++ b/launch.js
@@ -44,7 +44,7 @@
 
   u = bkcore.Utils.getURLParameter;
 
-  s = [['controlType', ['KEYBOARD', 'TOUCH', 'LEAP MOTION CONTROLLER', 'GAMEPAD'], 0, 0, 'Controls: '], ['quality', ['LOW', 'MID', 'HIGH'], 2, 2, 'Quality: '], ['hud', ['OFF', 'ON'], 1, 1, 'HUD: '], ['godmode', ['OFF', 'ON'], 0, 1, 'Godmode: ']];
+  s = [['controlType', ['KEYBOARD', 'TOUCH', 'LEAP MOTION CONTROLLER', 'GAMEPAD'], 0, 0, 'Controls: '], ['quality', ['LOW', 'MID', 'HIGH', 'VERY HIGH'], 3, 3, 'Quality: '], ['hud', ['OFF', 'ON'], 1, 1, 'HUD: '], ['godmode', ['OFF', 'ON'], 0, 1, 'Godmode: ']];
 
   _fn = function(a) {
     var e, f, _ref;


### PR DESCRIPTION
This patch does two related things:
- Removes the "platform" option. This was replaced with 4 quality values, which correspond with old platform+quality combinations. The code was modified so that the same decision points are still applied, but are now just based on the quality option.
- Adds a separate HUD option. Rather than disable the HUD for mobile automatically, it's now possible to have the HUD alongside mobile-quality graphics.

NB the HUD does still degrade performance significantly, but at least you can switch it on for mobile (while retaining all the other graphical optimisations for mobile). I might look at improving the HUD next.

Relates to #21
