### PR TITLE
Fix unbalanced h4 w/ h3 close-tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
       <h3>Graphics</h3>
       <p><b>HexMKI base model</b><br>Charnel</p>
       <p><b>Track texture</b><br>Nobiax</p>
-      <h4>Click anywhere to continue.</h3>
+      <h4>Click anywhere to continue.</h4>
     </div>
 
     <div id="leapinfo" style="display: none"></div>


### PR DESCRIPTION
Just fixing invalid HTML -- right now there's a `<h4>` which is closed by a `</h3>`. Should be a `</h4>`.